### PR TITLE
Inter-project dependencies won't fail build if no version provided on command line...

### DIFF
--- a/src/main/groovy/au/com/ish/gradle/ReleasePlugin.groovy
+++ b/src/main/groovy/au/com/ish/gradle/ReleasePlugin.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.GradleException
+import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.tasks.testing.*
 
 class ReleasePlugin implements Plugin<Project> {
@@ -43,7 +44,7 @@ class ReleasePlugin implements Plugin<Project> {
                         currentProject.configurations.each { configuration ->
                             project.logger.info("Checking for snapshot dependencies in $currentProject.path -> $configuration.name")
                             configuration.allDependencies.each { Dependency dependency ->
-                                if (dependency.version?.contains('SNAPSHOT')) {
+                                if (dependency.version?.contains('SNAPSHOT') && !(dependency instanceof ProjectDependency)) {
                                     snapshotDependencies.add("${dependency.group}:${dependency.name}:${dependency.version}")
                                 }
                             }


### PR DESCRIPTION
With the current codebase, any inter-project dependencies will fail a release build if a release version is not provided on the command line.  This is because the plugin unconditionally fails the build if it finds any snapshot dependencies.  The change ignores snapshot dependencies if and only if those dependencies are of type ProjectDependency.
