### PR TITLE
Using version 1.8.3 of svnkit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ repositories {
 
 dependencies {
 	compile gradleApi()
-	compile 'org.tmatesoft.svnkit:svnkit:1.8.0'
+	compile 'org.tmatesoft.svnkit:svnkit:1.8.3'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {


### PR DESCRIPTION
Version 1.8.0 of svnkit is not available in the Maven Central repository, causing an exception about this depencency not being found:

```
Could not resolve all dependencies for configuration ':classpath'.
   > Could not find org.tmatesoft.svnkit:svnkit:1.8.0.
     Required by:
         :test:unspecified > au.com.ish.gradle:release:2.2.2
```
