### PR TITLE
Implimentation of Enhancement: Override Commit Messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ build
 .gradle
 .idea
 release.iml
+/bin/
+.classpath
+.project
+.settings/

--- a/src/main/groovy/au/com/ish/gradle/ReleasePlugin.groovy
+++ b/src/main/groovy/au/com/ish/gradle/ReleasePlugin.groovy
@@ -78,6 +78,16 @@ class ReleasePlugin implements Plugin<Project> {
 
         releaseTask.description = "Release the project by setting a final non-snapshot version, building and creating a tag."
     }
+    
+    def String getMessage(project, extension) {
+        Closure message = extension.getMessage();
+        
+        if(message != null) {
+            return message.call();
+        } else {
+            return "#0000 Release ${project.version} from branch ${getSCMService().getBranchName()}"
+        }
+    }
 
     def String getProjectVersion() {
         project.logger.debug("release version specified? "+hasProperty('releaseVersion'))

--- a/src/main/groovy/au/com/ish/gradle/ReleasePluginExtension.groovy
+++ b/src/main/groovy/au/com/ish/gradle/ReleasePluginExtension.groovy
@@ -24,6 +24,7 @@ class ReleasePluginExtension {
   private String password
   private boolean releaseDryRun = false
   private boolean allowLocalModifications = false
+  private Closure message
 
   public ReleasePluginExtension(ReleasePlugin plugin) {
     this.plugin = plugin
@@ -132,6 +133,20 @@ class ReleasePluginExtension {
   */
   public getAllowLocalModifications() {
     return allowLocalModifications
+  }
+
+  /*
+    Sets the commit message to be used.
+  */
+  public setMessage(Closure message) {
+  	this.message = message;
+  }
+ 
+  /*
+    Get the commit message.
+  */
+  public Closure getMessage() {
+    return this.message;
   }
 
 }

--- a/src/test/groovy/au/com/ish/gradle/ReleasePluginTest.groovy
+++ b/src/test/groovy/au/com/ish/gradle/ReleasePluginTest.groovy
@@ -49,6 +49,7 @@ class ReleasePluginTest {
 			project.apply plugin: 'release'
 			release {
 				scm = "test"
+				message = {"Version: ${project.version}"}
 			}
 			version = release.projectVersion
 		}
@@ -72,6 +73,12 @@ class ReleasePluginTest {
 	@Test
 	public void checkSCMversion() {
 		assert project.release.scmVersion == "abc"
+	}
+	
+	@Test
+	public void checkCustomMessage() {
+		def message = project.release.getMessage().call();
+		assert message == "Version: xyz-SNAPSHOT";
 	}
 
 }


### PR DESCRIPTION
Hi,

I like your plugin, but I needed to be able to apply my own commit message. I saw that there was an existing enhancement request for this functionality and thought I would provide an implementation for it. I have kept the current behaviour/message if a custom message is not specified.

Hopefully this is ok.